### PR TITLE
Shrink the ES query JSON in link sharing

### DIFF
--- a/app/scripts/services/settingsStoreSvc.js
+++ b/app/scripts/services/settingsStoreSvc.js
@@ -91,7 +91,7 @@ angular.module('splain-app')
         $location.search({'solr':  searchSettings.solr.startUrl, 'fieldSpec': searchSettings.solr.fieldSpecStr});
       } else {
         $location.search({'esUrl':  searchSettings.es.searchUrl,
-                          'esQuery': searchSettings.es.searchArgsStr,
+                          'esQuery': JSON.stringify(JSON.parse(searchSettings.es.searchArgsStr)),
                           'fieldSpec': searchSettings.es.fieldSpecStr});
 
       }


### PR DESCRIPTION
This removes unneeded spaces from the JSON string stored in the URL to shrink the query down and make links more sharable. 